### PR TITLE
WIP: feat: add HKTAN Segment Version 7

### DIFF
--- a/packages/fints/src/segments/hitans.ts
+++ b/packages/fints/src/segments/hitans.ts
@@ -19,7 +19,7 @@ export class HITANS extends SegmentClass(HITANSProps) {
     protected serialize(): string[][] { throw new Error("Not implemented."); }
 
     protected deserialize(input: string[][]) {
-        if (![1, 2, 3, 4, 5, 6].includes(this.version)) {
+        if (![1, 2, 3, 4, 5, 6, 7].includes(this.version)) {
             throw new Error(`Unimplemented TAN method version ${this.version} encountered.`);
         }
         const [

--- a/packages/fints/src/tan-method.ts
+++ b/packages/fints/src/tan-method.ts
@@ -129,6 +129,35 @@ tanMethodArgumentMap.set(6, [
     "supportedMediaNumber",
 ]);
 
+tanMethodArgumentMap.set(7, [
+    "securityFunction",
+    "tanProcess",
+    "techId",
+    "dkId",
+    "dkVersion",
+    "name",
+    "maxLengthInput",
+    "allowedFormat",
+    "textReturnvalue",
+    "maxLengthReturnvalue",
+    "multiple",
+    "tanTimeDialogAssociation",
+    "cancellable",
+    "smsChargeAccountRequired",
+    "principalAccountRequired",
+    "challengeClassRequired",
+    "challengeStructured",
+    "initializationMode",
+    "descriptionRequired",
+    "hhdUcRequired",
+    "supportedMediaNumber",
+    "maxStatusRequestDecoupled",
+    "waitTimeBeforeFirstStatusRequest",
+    "waitTimeBeforeNextStatusRequest",
+    "manual",
+    "automated",
+]);
+
 export class TanMethod {
     public allowedFormat?: string;
     public cancellable?: boolean;
@@ -154,7 +183,14 @@ export class TanMethod {
     public textReturnvalue?: string;
     public zkaId?: string;
     public zkaVersion?: string;
+    public dkId?: string;
+    public dkVersion?: string;
     public version?: number;
+    public maxStatusRequestDecoupled?: number;
+    public waitTimeBeforeFirstStatusRequest?: number;
+    public waitTimeBeforeNextStatusRequest?: number;
+    public manual?: boolean;
+    public automated?: boolean;
 
     constructor(version: number, config?: string[]) {
         this.version = version;
@@ -187,5 +223,13 @@ export class TanMethod {
         this.textReturnvalue = map.get("textReturnvalue");
         this.zkaId = map.get("zkaId");
         this.zkaVersion = map.get("zkaVersion");
+        this.dkId = map.get("dkId");
+        this.dkVersion = map.get("dkVersion");
+        this.maxStatusRequestDecoupled = Parse.num(map.get("maxStatusRequestDecoupled"));
+        this.waitTimeBeforeFirstStatusRequest = Parse.num(map.get("waitTimeBeforeFirstStatusRequest"));
+        this.waitTimeBeforeNextStatusRequest = Parse.num(map.get("waitTimeBeforeNextStatusRequest"));
+        this.manual = Parse.bool(map.get("manual"));
+        this.automated = Parse.bool(map.get("automated"));
+
     }
 }


### PR DESCRIPTION
This pull request addresses #13 and adds HKTAN Segment Version #7. And resolves the issue I had while using `clients.accounts()`, however the use of the tan methods is not yet implemented.

See Section B.5.2 c) of the [[PIN/TAN] Specification](https://www.hbci-zka.de/spec/3_0.htm) for the added fields